### PR TITLE
fixed crash when launching editor 4.14.1

### DIFF
--- a/Source/Cubiquity/Classes/CubiquityMaterialSet.h
+++ b/Source/Cubiquity/Classes/CubiquityMaterialSet.h
@@ -12,8 +12,7 @@ class UCubiquityMaterialSet : public UObject
 	GENERATED_BODY()
 
 public:
-
-	UCubiquityMaterialSet() = default;
+	UCubiquityMaterialSet();
 
 	UFUNCTION(BlueprintCallable, Category = "Cubiquity")
 	void setMaterial(uint8 index, uint8 value);

--- a/Source/Cubiquity/Private/CubiquityMaterialSet.cpp
+++ b/Source/Cubiquity/Private/CubiquityMaterialSet.cpp
@@ -4,6 +4,10 @@
 
 #include "CubiquityMaterialSet.h"
 
+UCubiquityMaterialSet::UCubiquityMaterialSet() : Super()
+{
+}
+
 void UCubiquityMaterialSet::setMaterial(uint8 index, uint8 value)
 {
 	m_materialSet.setMaterial(index, value);

--- a/Source/Cubiquity/Private/CubiquityOctreeNode.cpp
+++ b/Source/Cubiquity/Private/CubiquityOctreeNode.cpp
@@ -52,8 +52,8 @@ void ACubiquityOctreeNode::Destroyed()
 
 void ACubiquityOctreeNode::initialiseOctreeNode(const Cubiquity::OctreeNode& newOctreeNode, UMaterialInterface* material)
 {
-	AttachRootComponentToActor(GetOwner());
-
+	AttachToActor(GetOwner(), FAttachmentTransformRules::KeepRelativeTransform);
+	
 	//UE_LOG(CubiquityLog, Log, TEXT("%d My absolute: %d %d %d     Parent absolute: %d %d %d     Relative: %d %d %d"), depth, nodeX, nodeY, nodeZ, parentX, parentY, parentZ, nodeX - parentX, nodeY - parentY, nodeZ - parentZ);
 	
 	structureLastSynced = 0;


### PR DESCRIPTION
Removed default keyword, it is used for automatic generation of a
default constructor, however UCubiquityMaterialSet inherites from
UObject, a simple call to it's constructor fixed it. Fixed warning for a
attachment as well.